### PR TITLE
chore: remove unused permissions.

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,9 +4,7 @@
    "author": "Kagiso Marvin Molekwa",
    "version": "0.9.0",
    "manifest_version": 3,
-   "permissions": [
-      "scripting"
-   ],
+   "permissions": [],
    "action": {
       "default_popup": "popup.html",
       "default_icon": {


### PR DESCRIPTION
Removes unused permissions since the Chrome extension was rejected solely because from this.